### PR TITLE
Make dir tree in README easier to read

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ Example
 Given a directory of JavaScript files:
 
 ```
--
- > index.js
- > fish.js
- > other_file.js
- > other_folder
-   > badger.js
-   > badger_fish.js
- > folder_with_index
-   > index.js
-   > other_file.js
+.
+├── fish.js
+├── folder_with_index
+│   ├── index.js
+│   └── other_file.js
+├── index.js
+├── other_file.js
+└── other_folder
+    ├── badger.js
+    └── badger_fish.js
 ```
 
 **index.js**


### PR DESCRIPTION
Change to use the output style from `tree` as it's easier to read. 
