### PR TITLE
Fixed git url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "http://bitbucket.org/pearlshare/require-dir-object.git"
+    "url": "http://github.com/pearlshare/require-dir-object.git"
   },
   "keywords": [
     "node",


### PR DESCRIPTION
Fixed git url in `package.json` from `bitbucket.org` -> `github.com`
